### PR TITLE
fix- bug of preference reset on refresh #194

### DIFF
--- a/traffic-dashboard/src/App.tsx
+++ b/traffic-dashboard/src/App.tsx
@@ -25,6 +25,7 @@ function App(): React.JSX.Element {
       mode,
     },
   });
+  
   return (
     <BrowserRouter>
       <ThemeProvider theme={theme}>

--- a/traffic-dashboard/src/stores/themeStore.ts
+++ b/traffic-dashboard/src/stores/themeStore.ts
@@ -1,15 +1,24 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 
 interface themeStore {
   mode: "light" | "dark";
   toggleColorMode: () => void;
 }
 
-export const useThemeStore = create<themeStore>((set) => ({
-  mode: "light",
-  toggleColorMode: () => {
-    set((state) => ({
-      mode: state.mode === "light" ? "dark" : "light",
-    }));
-  },
-}));
+export const useThemeStore = create<themeStore>()(
+  persist(
+    (set, get) => ({
+      mode: "dark",
+      toggleColorMode: () => {
+        set((state) => ({
+          mode: state.mode === "light" ? "dark" : "light",
+        }));
+      },
+    }),
+    {
+      name: "theme-mode",
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
This pull request addresses the issue reported in #194, where the dark mode preference is reset on page refresh.
The issue was caused by incorrect handling of user preferences.


A review after the changes:

https://github.com/sharkio-dev/sharkio/assets/114335827/0f8e3d03-ed72-4924-97c8-cf22b557e8ec

