### PR TITLE
fix: change http-status to handle status ranges

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,12 +13,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "integration" ]
+    branches: ["main", "integration"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '38 7 * * 1'
+    - cron: "38 7 * * 1"
 
 jobs:
   analyze:
@@ -38,45 +38,44 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/traffic-dashboard/src/components/http-status/http-status.tsx
+++ b/traffic-dashboard/src/components/http-status/http-status.tsx
@@ -11,18 +11,16 @@ export const HttpStatus: React.FC<IHttpMethodProps> = ({ status }) => {
 };
 
 function statusColor(status: number) {
-  switch (status) {
-    case 201:
-    case 200: {
-      return "success";
-    }
-    case 404: {
-      return "warning";
-    }
-    case 500: {
-      return "error";
-    }
-    default:
-      return "default";
-  }
+  /* maps statuses numbers to color string e.g. 201 -> success */
+  const statusesMap = {
+    2: "success",
+    4: "warning",
+    5: "error",
+  } as any;
+  return statusesMap[status.toString().slice(0, 1)] || "default";
 }
+/*tests (TODO: add real ones)*/
+/* console.log(statusColor(100)) -> default*/
+/* console.log(statusColor(202)) -> success*/
+/* console.log(statusColor(402)) -> wiarning*/
+/* console.log(statusColor(502)) -> error*/

--- a/traffic-dashboard/src/components/http-status/http-status.tsx
+++ b/traffic-dashboard/src/components/http-status/http-status.tsx
@@ -19,8 +19,3 @@ function statusColor(status: number) {
   } as any;
   return statusesMap[status.toString().slice(0, 1)] || "default";
 }
-/*tests (TODO: add real ones)*/
-/* console.log(statusColor(100)) -> default*/
-/* console.log(statusColor(202)) -> success*/
-/* console.log(statusColor(402)) -> wiarning*/
-/* console.log(statusColor(502)) -> error*/


### PR DESCRIPTION
## Description

changes http-status component to handle statuses numbers of specific status ranges.
like status 219 , which before was mapped to `default` now mapped to `success`

Closes #219 

## How to Test

Outline the steps to test the changes made in this pull request. Provide as much detail as necessary so that reviewers can easily verify the changes.

1. Step 1
2. Step 2
3. ...

## Additional Notes

Include any other relevant information, context, or considerations related to this pull request.

## Checklist

Please make sure you've done the following before submitting this pull request:

- [ ] Ran all existing tests to ensure they pass.
- [ ] Added new tests to cover the changes (if applicable).
- [ ] Reviewed the code for any potential issues or bugs.
- [ ] Updated the documentation (if needed) to reflect the changes.
- [ ] Squashed your commits into a single logical commit (if necessary).
