### PR TITLE
Now images in the Setup section of the documentation won't be squished (vertically).

### DIFF
--- a/client/src/pages/docs/SharkioDocsSetupPage.tsx
+++ b/client/src/pages/docs/SharkioDocsSetupPage.tsx
@@ -18,8 +18,7 @@ export const SharkioDocsSetupPage = () => {
         <img
           src="/login.png"
           alt=""
-          className="rounded-lg border-2 border-border-color mt-4"
-          style="width:90%"
+          className="rounded-lg border-2 border-border-color mt-4 w-[90%]"
         />
       </SharkioDocsSection>
 
@@ -37,8 +36,7 @@ export const SharkioDocsSetupPage = () => {
         <img
           src="/apiKeys.png"
           alt=""
-          className="rounded-lg border-2 border-border-color mt-4"
-          style="width:90%"
+          className="rounded-lg border-2 border-border-color mt-4 w-[90%]"
         />
       </SharkioDocsSection>
 

--- a/client/src/pages/docs/SharkioDocsSetupPage.tsx
+++ b/client/src/pages/docs/SharkioDocsSetupPage.tsx
@@ -18,7 +18,7 @@ export const SharkioDocsSetupPage = () => {
         <img
           src="/login.png"
           alt=""
-          className="w-full rounded-lg h-96 border-2 border-border-color mt-4"
+          className="w-80 rounded-lg border-2 border-border-color mt-4"
         />
       </SharkioDocsSection>
 
@@ -36,7 +36,7 @@ export const SharkioDocsSetupPage = () => {
         <img
           src="/apiKeys.png"
           alt=""
-          className="w-full rounded-lg h-96 border-2 border-border-color mt-4"
+          className="w-80 rounded-lg border-2 border-border-color mt-4"
         />
       </SharkioDocsSection>
 

--- a/client/src/pages/docs/SharkioDocsSetupPage.tsx
+++ b/client/src/pages/docs/SharkioDocsSetupPage.tsx
@@ -18,7 +18,8 @@ export const SharkioDocsSetupPage = () => {
         <img
           src="/login.png"
           alt=""
-          className="w-80 rounded-lg border-2 border-border-color mt-4"
+          className="rounded-lg border-2 border-border-color mt-4"
+          style="width:90%"
         />
       </SharkioDocsSection>
 
@@ -36,7 +37,8 @@ export const SharkioDocsSetupPage = () => {
         <img
           src="/apiKeys.png"
           alt=""
-          className="w-80 rounded-lg border-2 border-border-color mt-4"
+          className="rounded-lg border-2 border-border-color mt-4"
+          style="width:90%"
         />
       </SharkioDocsSection>
 


### PR DESCRIPTION
## Description

This tiny Pull Request fixes images in the Setup section of Sharkio Docs, so they won't be squished anymore.

## Related Issues or Pull Requests

I couldn't find any Issue or Pull Request related to this.

## Proposed Changes

- Made images in the Setup section of Sharkio Docs, so they won't be squished anymore.

## Screenshots (if applicable)

Before:

![image](https://github.com/sharkio-dev/sharkio/assets/127299159/2092264e-f9b1-47d0-95ce-01dd393414fc)

After:

![image](https://github.com/sharkio-dev/sharkio/assets/127299159/0492863f-0411-43ad-bfd1-ce594c11df85)

![image](https://github.com/sharkio-dev/sharkio/assets/127299159/3ff624fa-bf15-4d03-b301-3a055a187de2)


## How to Test

Simply run an instance of the updated code, these changes are already applied.

## Additional Notes

Also changed the `width` of these two images to 90% so they won't be too large.

## Checklist

- [x] Ran all existing tests to ensure they pass.
- [N/A] Added new tests to cover the changes (if applicable).
- [x] Reviewed the code for any potential issues or bugs.
- [N/Needed] Updated the documentation (if needed) to reflect the changes.
- [N/Necssary] Squashed your commits into a single logical commit (if necessary).
