### PR TITLE
fix:UI break if url too long

### DIFF
--- a/client/src/pages/sniffers/SniffersPage/Sniffer.tsx
+++ b/client/src/pages/sniffers/SniffersPage/Sniffer.tsx
@@ -10,14 +10,13 @@ import "reactflow/dist/style.css";
 import { VscTypeHierarchy } from "react-icons/vsc";
 
 const SnifferNode = (props: NodeProps) => {
-  const truncatedAddress = `${props.data.address.substring(0, 40)}...`;
   return (
     <div className="flex flex-col items-center justify-center">
       <div className="text-[6px]">{props.data.label}</div>
       <div className="flex flex-row items-center gap-2 w-24 bg-primary p-2 rounded-lg shadow-md justify-center">
         <VscTypeHierarchy className="text-2xl" />
       </div>
-      <div className="text-[6px]">{truncatedAddress}</div>
+      <div className="text-[6px] max-w-[105px] truncate">{props.data.address}</div>
       <Handle type="source" position={Position.Right} id="a" />
       <Handle type="target" position={Position.Left} id="b" />
     </div>

--- a/client/src/pages/sniffers/SniffersPage/Sniffer.tsx
+++ b/client/src/pages/sniffers/SniffersPage/Sniffer.tsx
@@ -10,13 +10,14 @@ import "reactflow/dist/style.css";
 import { VscTypeHierarchy } from "react-icons/vsc";
 
 const SnifferNode = (props: NodeProps) => {
+  const truncatedAddress = `${props.data.address.substring(0, 40)}...`;
   return (
     <div className="flex flex-col items-center justify-center">
       <div className="text-[6px]">{props.data.label}</div>
       <div className="flex flex-row items-center gap-2 w-24 bg-primary p-2 rounded-lg shadow-md justify-center">
         <VscTypeHierarchy className="text-2xl" />
       </div>
-      <div className="text-[6px]">{props.data.address}</div>
+      <div className="text-[6px]">{truncatedAddress}</div>
       <Handle type="source" position={Position.Right} id="a" />
       <Handle type="target" position={Position.Left} id="b" />
     </div>


### PR DESCRIPTION
## Description

Please provide a brief description of the changes made in this pull request.
This pull request addresses the issue where the UI breaks when the URL is too long. To mitigate this, the URL in the `SnifferNode` component is now truncated to improve the overall UI layout.

## Related Issues or Pull Requests
This pull request is related to issue #330 

## Proposed Changes

- Truncate the `address` property in the `SnifferNode` component to prevent long URLs from breaking the UI layout.


## How to Test

To test the changes, follow these steps:

1. Open a page with the `SnifferNode` component.
2. Verify that the URL is properly truncated and doesn't break the UI.
3. Test with URLs of varying lengths to ensure the layout remains consistent.

## Additional Notes

- The truncation length is currently set to 20 characters. Adjustments can be made based on UI design preferences.
- Reviewers are encouraged to provide feedback on the chosen truncation length.

## Checklist

Please make sure you've done the following before submitting this pull request:

- [x] Ran all existing tests to ensure they pass.
- [ ] Added new tests to cover the changes (if applicable).
- [ ] Reviewed the code for any potential issues or bugs.
- [ ] Updated the documentation (if needed) to reflect the changes.
- [ ] Squashed your commits into a single logical commit (if necessary).
