### PR TITLE
Adding missing support for some url formats

### DIFF
--- a/client/src/utils/ValidateHttpUrl.tsx
+++ b/client/src/utils/ValidateHttpUrl.tsx
@@ -1,5 +1,5 @@
 export const validateHttpUrlFormat = (string: string) => {
-  const domainPattern = /^https?:\/\/[a-zA-Z0-9-]+(\.[a-zA-Z]{2,})+$/;
+  const domainPattern = /^https?:\/\/[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*$/;
   const localhostPattern = /^(http|https):\/\/localhost:\d+$/;
 
   return domainPattern.test(string) || localhostPattern.test(string);

--- a/client/src/utils/ValidateHttpUrl.tsx
+++ b/client/src/utils/ValidateHttpUrl.tsx
@@ -1,5 +1,5 @@
 export const validateHttpUrlFormat = (string: string) => {
-  const domainPattern = /^https?:\/\/[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*$/;
+  const domainPattern = /^https?:\/\/[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*(:\d+)?$/;
   const localhostPattern = /^(http|https):\/\/localhost:\d+$/;
 
   return domainPattern.test(string) || localhostPattern.test(string);


### PR DESCRIPTION
Fixed the regex that validates url formats to support the Forwarding  link we get from ngrok:

 This is how the app looks with the new support: 
 
 Inserting the url we got from ngrok: 
 
![image](https://github.com/sharkio-dev/sharkio/assets/34707669/d5341df6-e5b3-40b2-bac4-857ffe63fb69)
![image](https://github.com/sharkio-dev/sharkio/assets/34707669/b627c046-94bf-4ef6-abac-847bf2dadb54)

Other formats are also supported : 
![image](https://github.com/sharkio-dev/sharkio/assets/34707669/3452b48b-8795-4dbe-a4f5-a58e0c1e3fce)
![image](https://github.com/sharkio-dev/sharkio/assets/34707669/c5ab3a7b-6140-47d1-861f-0eca026eec0f)
![image](https://github.com/sharkio-dev/sharkio/assets/34707669/e5d86219-9291-40a7-bb71-335530f40ae9)
