### PR TITLE
Adding key to sniffer list

### DIFF
--- a/client/src/pages/sniffers/HomePage.tsx
+++ b/client/src/pages/sniffers/HomePage.tsx
@@ -100,7 +100,7 @@ export const HomePage = () => {
 
       <div className="grid grid-cols-2 gap-2 w-full">
         {sniffers.map((sniffer) => (
-          <SnifferBox sniffer={sniffer} />
+          <SnifferBox key={sniffer.id} sniffer={sniffer} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
I noticed that in this list of sniffers: 

![image](https://github.com/sharkio-dev/sharkio/assets/34707669/9f9d4a41-995b-41da-877b-0ed47c9a764f)


There was no key to each element and that caused the data to display wrong (reproduced by deleting a sniffer and then clicking edit on another one) after the list changed.